### PR TITLE
Fix static resource preflight route in preflight handler adding

### DIFF
--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -152,7 +152,8 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
                 # Preflight handler already added for this resource.
                 return
 
-            preflight_route = resource.set_options_route(handler)
+            resource.set_options_route(handler)
+            preflight_route = resource._routes[hdrs.METH_OPTIONS]
             self._preflight_routes.add(preflight_route)
             self._resources_with_preflight_handlers.add(resource)
 

--- a/tests/aio_test_base.py
+++ b/tests/aio_test_base.py
@@ -23,12 +23,13 @@ import concurrent.futures
 
 
 @asyncio.coroutine
-def create_server(protocol_factory, loop=None):
+def create_server(protocol_factory, loop=None, sock=None):
     """Create server listening on random port"""
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    sock.listen(10)
+    if sock is None:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(10)
 
     if loop is None:
         loop = asyncio.get_event_loop()

--- a/tests/unit/test_cors_config.py
+++ b/tests/unit/test_cors_config.py
@@ -77,3 +77,14 @@ class TestCorsConfig(unittest.TestCase):
         self.assertEqual(len(self.app.router.keys()), 1)
         self.cors.add(route)
         self.assertEqual(len(self.app.router.keys()), 1)
+
+    def test_static_resource(self):
+        """Test adding static resource."""
+        self.assertEqual(len(self.app.router.keys()), 0)
+        self.app.router.add_static(
+            "/file", "/", name="dynamic_named_route")
+        self.assertEqual(len(self.app.router.keys()), 1)
+        for resource in list(self.app.router.resources()):
+            if issubclass(resource, web.StaticResource):
+                self.cors.add(resource)
+        self.assertEqual(len(self.app.router.keys()), 1)


### PR DESCRIPTION
Added tests for:
* OPTIONS request to static route
* CORS config of static resource
* Also fixed server starts in integration tests.