### PR TITLE
setup.py: Use platform specifiers instead of extras_require

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+0.5.3 (XXXX-XX-XX)
+------------------
+
+- Fix `typing` being installed on Python 3.6.
+
 0.5.2 (2017-03-28)
 ------------------
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   - "powershell ./install_python_and_pip.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
+  - "pip install -U pip setuptools wheel"
   - "pip list"
   - "pip install -r requirements-dev.txt"
   - "python setup.py develop"

--- a/setup.py
+++ b/setup.py
@@ -50,13 +50,12 @@ setup(
     )),
     packages=["aiohttp_cors"],
     setup_requires=[
-        # Setuptools fixed environment markers (":python_version < '3.5'")
-        # in 17.1, and pip in 6.
-        # TODO: Doesn't work due to
+        # Environment markers were implemented and stabilized in setuptools
+        # v20.8.1 (see <http://stackoverflow.com/a/32643122/391865>).
+        "setuptools>=20.8.1",
+        # If line above doesn't work, check that you have at least
+        # setuptools v19.4 (released 2016-01-16):
         # <https://github.com/pypa/setuptools/issues/141>
-        # which were fixed in setuptools 19.4 (released 2016-01-16)
-        # "pip>=6",
-        # "setuptools>=17.1",
     ] + pytest_runner,
     tests_require=[
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -66,13 +66,8 @@ setup(
     test_suite="tests",
     install_requires=[
         "aiohttp>=1.1",
+        "typing;python_version<'3.5'",
     ],
-    extras_require={
-        # TODO: Rich comparison in environment markers are broken in
-        # setuptools<17.1 and pip<6.
-        # ":python_version < '3.5'": ["typing"],
-        ":python_version == '3.4'": ["typing"],
-    },
     license=about["__license__"],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Use platform specifiers to declare dependencies that apply only to
Python 3.4 and older, rather than extras_require. The latter does not
seem to work with the current versions of setuptools, and only
the former is mentioned in the documentation.