### PR TITLE
Add py.typed marker file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include CHANGES.rst
 include README.rst
 recursive-include tests *.py
 include tests/integration/test_page.html
+include aiohttp_cors/py.typed

--- a/aiohttp_cors/cors_config.py
+++ b/aiohttp_cors/cors_config.py
@@ -225,8 +225,6 @@ class CorsConfig:
 
         self.defaults = _parse_config_options(defaults)
 
-        self._cors_impl = None
-
         self._resources_router_adapter = None
         self._resources_cors_impl = None
 

--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -145,6 +145,7 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
         Should fail if there are conflicting user-defined OPTIONS handlers.
         """
 
+        resource: Union[web.Resource, web.StaticResource, web.ResourceRoute]
         if isinstance(routing_entity, web.Resource):
             resource = routing_entity
 

--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -131,8 +131,8 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
         # Mapping from Resource to _ResourceConfig.
         self._resource_config: Dict[web.AbstractResource, _ResourceConfig] = {} 
 
-        self._resources_with_preflight_handlers = set()  # type: Set[web.AbstractResource]
-        self._preflight_routes = set()  # type: Set[web.AbstractRoute]
+        self._resources_with_preflight_handlers: Set[web.AbstractResource] = set()
+        self._preflight_routes: Set[web.AbstractRoute] = set()
 
     def add_preflight_handler(
             self,

--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -16,7 +16,7 @@
 """
 import collections
 
-from typing import Union
+from typing import Dict, Set, Union
 
 from aiohttp import web
 from aiohttp import hdrs
@@ -129,10 +129,10 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
         self._default_config = defaults
 
         # Mapping from Resource to _ResourceConfig.
-        self._resource_config = {}
+        self._resource_config = {}  # type: Dict[web.AbstractResource, _ResourceConfig]
 
-        self._resources_with_preflight_handlers = set()
-        self._preflight_routes = set()
+        self._resources_with_preflight_handlers = set()  # type: Set[web.AbstractResource]
+        self._preflight_routes = set()  # type: Set[web.AbstractRoute]
 
     def add_preflight_handler(
             self,
@@ -204,7 +204,7 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
         """Is CORS is configured for the resource"""
         return resource in self._resources_with_preflight_handlers
 
-    def _request_route(self, request: web.Request) -> web.ResourceRoute:
+    def _request_route(self, request: web.Request) -> web.AbstractRoute:
         match_info = request.match_info
         assert isinstance(match_info, web.UrlMappingMatchInfo)
         return match_info.route

--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -129,7 +129,7 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
         self._default_config = defaults
 
         # Mapping from Resource to _ResourceConfig.
-        self._resource_config = {}  # type: Dict[web.AbstractResource, _ResourceConfig]
+        self._resource_config: Dict[web.AbstractResource, _ResourceConfig] = {} 
 
         self._resources_with_preflight_handlers = set()  # type: Set[web.AbstractResource]
         self._preflight_routes = set()  # type: Set[web.AbstractRoute]
@@ -145,7 +145,7 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
         Should fail if there are conflicting user-defined OPTIONS handlers.
         """
 
-        resource = None  # type: Union[web.Resource, web.StaticResource, web.ResourceRoute]  # type: ignore
+        resource: Union[web.Resource, web.StaticResource, web.ResourceRoute, None] = None  
         if isinstance(routing_entity, web.Resource):
             resource = routing_entity
 

--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -145,7 +145,7 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
         Should fail if there are conflicting user-defined OPTIONS handlers.
         """
 
-        resource: Union[web.Resource, web.StaticResource, web.ResourceRoute]
+        resource = None  # type: Union[web.Resource, web.StaticResource, web.ResourceRoute]  # type: ignore
         if isinstance(routing_entity, web.Resource):
             resource = routing_entity
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ test = pytest
 
 [tool:pytest]
 addopts= --cov=aiohttp_cors --cov-report=term --cov-report=html --cov-branch --no-cov-on-fail
+
+[mypy]
+files = aiohttp_cors

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         read_file("CHANGES.rst"),
     )),
     packages=["aiohttp_cors"],
+    include_package_data=True,
     setup_requires=[
         # Environment markers were implemented and stabilized in setuptools
         # v20.8.1 (see <http://stackoverflow.com/a/32643122/391865>).

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     )),
     packages=["aiohttp_cors"],
     include_package_data=True,
+    zip_safe=False,
     setup_requires=[
         # Environment markers were implemented and stabilized in setuptools
         # v20.8.1 (see <http://stackoverflow.com/a/32643122/391865>).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Type checkers look for a `py.typed` file before doing type-checking on libraries imported by other code (see PEP 561).

Adding `include_package_data=True` to setup.py means that the marker file will also be included in bdists (i.e. wheels), not just sdists.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Users who use mypy for type-checking will now be able to make use of the type hints in aiohttp-cors, i.e. if they are currently getting an error which looks like this:

    error: Cannot find module named 'aiohttp_cors'

they will stop getting this error.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

none

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist – n/a
- [ ] Documentation reflects the changes – n/a
- [ ] Add a new news fragment into the `CHANGES` folder – what `CHANGES` folder?
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
