### PR TITLE
Test instance type by isinstance, not issubclass

### DIFF
--- a/tests/unit/test_cors_config.py
+++ b/tests/unit/test_cors_config.py
@@ -103,7 +103,7 @@ def test_static_resource(app, cors):
         "/file", "/", name="dynamic_named_route")
     assert len(app.router.keys()) == 1
     for resource in list(app.router.resources()):
-        if issubclass(resource, web.StaticResource):
+        if isinstance(resource, web.StaticResource):
             cors.add(resource)
     assert len(app.router.keys()) == 1
 


### PR DESCRIPTION
Fixes https://github.com/aio-libs/aiohttp-cors/issues/277

<!-- Thank you for your contribution! -->

## What do these changes do?

Use a function that checks if and object is an instance of class, instead of a function that chcks if a class is a sublass of a class.

## Are there changes in behavior for the user?

No, tests only.

## Related issue number

https://github.com/aio-libs/aiohttp-cors/issues/277

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist - the change is in tests
- [x] Documentation reflects the changes - not needed
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`


There is no CHANGES folder.