### PR TITLE
Use pytest-aiohttp in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     ] + pytest_runner,
     tests_require=[
         "pytest",
+        "pytest-aiohttp",
         "pytest-cov",
         "pytest-pylint",
         "selenium",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py34, py35, check
 commands = {envpython} setup.py test
 deps =
     pytest
+    pytest-aiohttp
 
 [testenv:check]
 deps =


### PR DESCRIPTION
Otherwise, we get:

E       fixture 'aiohttp_client' not found

<!-- Thank you for your contribution! -->

## What do these changes do?

Add a test dependency on pytest-aiohttp.

## Are there changes in behavior for the user?

No. Tests only.

## Related issue number

I haven't opened one.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist - without his, the tests won't run
- [x] Documentation reflects the changes - not needed
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`

There is no CHANGES folder.