### PR TITLE
Resolve KeyError exception when calling unsupported request method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
  CHANGES
 =========
 
+0.8.0 (XXXX-XX-XX)
+==================
+
+- Resolve ``KeyError`` exception when requesting with an unsupported
+  method (#298)
+
 0.7.0 (2018-03-05)
 ==================
 

--- a/aiohttp_cors/cors_config.py
+++ b/aiohttp_cors/cors_config.py
@@ -154,7 +154,15 @@ class _CorsConfigImpl(_PreflightHandler):
 
         # Processing response of non-preflight CORS-enabled request.
 
-        config = self._router_adapter.get_non_preflight_request_config(request)
+        try:
+            config = self._router_adapter.get_non_preflight_request_config(request)
+        except KeyError as e:
+            if response.status == 405 and e.args[0] == "method not supported":
+                # Permit the response if the method is not supported - e.g: when
+                # using a class derived from web.View and CorsViewMixin
+                return
+
+            raise
 
         # Handle according to part 6.1 of the CORS specification.
 

--- a/aiohttp_cors/mixin.py
+++ b/aiohttp_cors/mixin.py
@@ -25,7 +25,7 @@ class CorsViewMixin(_PreflightHandler):
         method = getattr(cls, request_method.lower(), None)
 
         if not method:
-            raise KeyError()
+            raise KeyError("method not supported")
 
         config_property_key = "{}_cors_config".format(request_method.lower())
 


### PR DESCRIPTION
## What do these changes do?

When using a web.View class, and querying with an unsupported request method (e.g: class implements GET, client queries with POST), the client would receive an "Empty Reply" from the server, and the server would log a KeyError exception.

This patch resolves the issue, and permits the partially prepared 405 response through to the client.

I'm not sure if this abides by the CORS rules, but it's certainly better than an exception and no response.

## Are there changes in behavior for the user?

No changes required.

## Related issue number

- #178 - after applying this fix, the `KeyError` and "_Empty Reply_" are still present.
- #241 - possibly

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] ~~Documentation reflects the changes~~ (N/A)
- [x] Add a new news fragment into the `CHANGES` folder

## Tests

I'm not sure how to go about testing this fix, but I have provided a demo application and `curl` comamnd to demonstrate it below.

```python
from aiohttp import web
import aiohttp_cors

router = web.RouteTableDef()

@router.view('/ping')
class Ping(web.View, aiohttp_cors.CorsViewMixin):
    async def get(self):
        return web.Response(status=200, text='pong')

app = web.Application()
app.add_routes(router)

cors_defaults = {
    '*': aiohttp_cors.ResourceOptions(
        max_age = 3600,
        allow_methods = '*',
        allow_headers = '*',
        expose_headers = '*',
        allow_credentials = True,
    )
}
cors = aiohttp_cors.setup(app, defaults=cors_defaults)

for route in app.router.routes():
    cors.add(route)

web.run_app(app, port=8080)
```

```bash
curl -D- http://localhost:8080/ping
curl -D- -XPOST http://localhost:8080/ping
```