### PR TITLE
Add a Vary: Origin header when the response headers vary according to the origin.

### DIFF
--- a/aiohttp_cors/cors_config.py
+++ b/aiohttp_cors/cors_config.py
@@ -190,6 +190,7 @@ class _CorsConfigImpl(_PreflightHandler):
         # Process according to CORS 6.1.3.
         # Set allowed origin.
         response.headers[hdrs.ACCESS_CONTROL_ALLOW_ORIGIN] = origin
+        response.headers[hdrs.VARY] = hdrs.ORIGIN
         if options.allow_credentials:
             # Set allowed credentials.
             response.headers[hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS] = _TRUE

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -147,6 +147,7 @@ async def test_simple_no_origin(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -166,6 +167,7 @@ async def test_simple_allowed_origin(aiohttp_client, make_app):
 
     for hdr, val in {
             hdrs.ACCESS_CONTROL_ALLOW_ORIGIN: 'http://client1.example.org',
+            hdrs.VARY: hdrs.ORIGIN,
     }.items():
         assert resp.headers.get(hdr) == val
 
@@ -193,6 +195,7 @@ async def test_simple_not_allowed_origin(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -214,6 +217,7 @@ async def test_simple_explicit_port(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -235,6 +239,7 @@ async def test_simple_different_scheme(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -263,6 +268,7 @@ async def test_cred_no_origin(aiohttp_client, app_for_credentials):
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -281,6 +287,7 @@ async def test_cred_allowed_origin(aiohttp_client, app_for_credentials):
 
     for hdr, val in {
             hdrs.ACCESS_CONTROL_ALLOW_ORIGIN: 'http://client1.example.org',
+            hdrs.VARY: hdrs.ORIGIN,
             hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS: "true"}.items():
         assert resp.headers.get(hdr) == val
 
@@ -306,6 +313,7 @@ async def test_cred_disallowed_origin(aiohttp_client, app_for_credentials):
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -326,6 +334,7 @@ async def test_simple_expose_headers_no_origin(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -346,6 +355,7 @@ async def test_simple_expose_headers_allowed_origin(aiohttp_client, make_app):
 
     for hdr, val in {
             hdrs.ACCESS_CONTROL_ALLOW_ORIGIN: 'http://client1.example.org',
+            hdrs.VARY: hdrs.ORIGIN,
             hdrs.ACCESS_CONTROL_EXPOSE_HEADERS:
             SERVER_CUSTOM_HEADER_NAME}.items():
         assert resp.headers.get(hdr) == val
@@ -375,6 +385,7 @@ async def test_simple_expose_headers_not_allowed_origin(aiohttp_client,
                         hdrs.ACCESS_CONTROL_ALLOW_ORIGIN,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_CREDENTIALS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -397,6 +408,7 @@ async def test_preflight_default_no_origin(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_METHODS,
                         hdrs.ACCESS_CONTROL_ALLOW_HEADERS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -423,6 +435,7 @@ async def test_preflight_default_no_method(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_METHODS,
                         hdrs.ACCESS_CONTROL_ALLOW_HEADERS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -452,6 +465,7 @@ async def test_preflight_default_origin_and_method(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_MAX_AGE,
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_HEADERS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -478,6 +492,7 @@ async def test_preflight_default_disallowed_origin(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_METHODS,
                         hdrs.ACCESS_CONTROL_ALLOW_HEADERS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 
@@ -505,6 +520,7 @@ async def test_preflight_default_disallowed_method(aiohttp_client, make_app):
                         hdrs.ACCESS_CONTROL_EXPOSE_HEADERS,
                         hdrs.ACCESS_CONTROL_ALLOW_METHODS,
                         hdrs.ACCESS_CONTROL_ALLOW_HEADERS,
+                        hdrs.VARY,
                     }:
         assert header_name not in resp.headers
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

According to the [fetch spec](https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches), I added a `Vary: Origin` when the response varies according to the origin, to avoid cache issues (like an `Access-Control-Allow-Origin` for a domain being  cached then delivered to other origins).

## Are there changes in behavior for the user?

It should fix some cache issues, typically when the responses get through an HTTP cache like Varnish.

## Related issue number

Closes https://github.com/aio-libs/aiohttp-cors/issues/351

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
