### PR TITLE
Replace @asyncio.coroutine decorator with async def

### DIFF
--- a/tests/unit/test_cors_config.py
+++ b/tests/unit/test_cors_config.py
@@ -29,8 +29,7 @@ async def _handler(request):
 
 class _View(web.View, CorsViewMixin):
 
-    @asyncio.coroutine
-    def get(self):
+    async def get(self):
         return web.Response(text="Done")
 
 


### PR DESCRIPTION
In Python 3.11 @asyncio.coroutine decorator was removed and it should
be replaced with async def call.

This PR needs  #278 if it ever gets merged. 
<!-- Thank you for your contribution! -->

## What do these changes do?
Fixes tests for Python 3.11.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes: #280

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
