### PR TITLE
Use typing.Mapping for compatibility with Python < 3.9

### DIFF
--- a/aiohttp_cors/__init__.py
+++ b/aiohttp_cors/__init__.py
@@ -14,8 +14,7 @@
 
 """CORS support for aiohttp."""
 
-from collections.abc import Mapping
-from typing import Any, Union
+from typing import Any, Mapping, Union
 
 from aiohttp import web
 

--- a/aiohttp_cors/cors_config.py
+++ b/aiohttp_cors/cors_config.py
@@ -16,8 +16,7 @@
 
 import collections
 import warnings
-from collections.abc import Mapping
-from typing import Any, Union
+from typing import Any, Mapping, Union
 
 from aiohttp import hdrs, web
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Import `typing.Mapping` rather than `collections.abc.Mapping`. This reverts a change recently introduced in c4a4ead, which causes `TypeError` on Python 3.8 due to the use of subscript operator in various typehints. Subscript was not supported by `collections.abc.Mapping` until Python 3.9.

## Are there changes in behavior for the user?

No change other than fixing the exceptions on old versions of Python, AFAIK.

## Related issue number

Fixes #502 

## Checklist

- [ x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
