### PR TITLE
Fix accessing private aiohttp attribute

### DIFF
--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -183,8 +183,7 @@ class ResourcesUrlDispatcherRouterAdapter(AbstractRouterAdapter):
                 # Preflight handler already added for this resource.
                 return
 
-            resource.set_options_route(handler)
-            preflight_route = resource._routes[hdrs.METH_OPTIONS]
+            preflight_route = resource.set_options_route(handler)
             self._preflight_routes.add(preflight_route)
             self._resources_with_preflight_handlers.add(resource)
 


### PR DESCRIPTION
Requires aiohttp 3.15+