### PR TITLE
Add missing type hints and fix README examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,12 +136,10 @@ that you want to expose:
 
 .. code-block:: python
 
-    import asyncio
     from aiohttp import web
     import aiohttp_cors
 
-    @asyncio.coroutine
-    def handler(request):
+    async def handler(request):
         return web.Response(
             text="Hello!",
             headers={
@@ -351,24 +349,22 @@ You can also use ``CorsViewMixin`` on ``web.View``:
     class CorsView(web.View, CorsViewMixin):
 
         cors_config = {
-            "*": ResourceOption(
+            "*": ResourceOptions(
                 allow_credentials=True,
                 allow_headers="X-Request-ID",
             )
         }
 
-        @asyncio.coroutine
-        def get(self):
+        async def get(self):
             return web.Response(text="Done")
 
         @custom_cors({
-            "*": ResourceOption(
+            "*": ResourceOptions(
                 allow_credentials=True,
                 allow_headers="*",
             )
         })
-        @asyncio.coroutine
-        def post(self):
+        async def post(self):
             return web.Response(text="Done")
 
     cors = aiohttp_cors.setup(app, defaults={

--- a/aiohttp_cors/__init__.py
+++ b/aiohttp_cors/__init__.py
@@ -15,7 +15,7 @@
 """CORS support for aiohttp."""
 
 from collections.abc import Mapping
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from aiohttp import web
 
@@ -56,7 +56,7 @@ APP_CONFIG_KEY: web.AppKey[CorsConfig] = web.AppKey("aiohttp_cors", CorsConfig)
 def setup(
     app: web.Application,
     *,
-    defaults: Mapping[str, Union[ResourceOptions, Mapping[str, Any]]] = None
+    defaults: Optional[Mapping[str, Union[ResourceOptions, Mapping[str, Any]]]] = None
 ) -> CorsConfig:
     """Setup CORS processing for the application.
 

--- a/aiohttp_cors/cors_config.py
+++ b/aiohttp_cors/cors_config.py
@@ -17,7 +17,7 @@
 import collections
 import warnings
 from collections.abc import Mapping
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from aiohttp import hdrs, web
 
@@ -45,8 +45,8 @@ _SIMPLE_RESPONSE_HEADERS = frozenset(
 
 
 def _parse_config_options(
-    config: Mapping[str, Union[ResourceOptions, Mapping[str, Any]]] = None,
-):
+    config: Optional[Mapping[str, Union[ResourceOptions, Mapping[str, Any]]]] = None,
+) -> Any:
     """Parse CORS configuration (default or per-route)
 
     :param config:
@@ -113,7 +113,7 @@ class _CorsConfigImpl(_PreflightHandler):
         # headers on non-preflight requests.
         self._app.on_response_prepare.append(self._on_response_prepare)
 
-    def add(self, routing_entity, config: _ConfigType = None):
+    def add(self, routing_entity: Any, config: Optional[_ConfigType] = None) -> Any:
         """Enable CORS for specific route or resource.
 
         If route is passed CORS is enabled for route's resource.
@@ -216,9 +216,9 @@ class CorsConfig:
         self,
         app: web.Application,
         *,
-        defaults: _ConfigType = None,
-        router_adapter: AbstractRouterAdapter = None,
-    ):
+        defaults: Optional[_ConfigType] = None,
+        router_adapter: Optional[AbstractRouterAdapter] = None,
+    ) -> None:
         """Construct CORS configuration.
 
         :param app:
@@ -245,7 +245,12 @@ class CorsConfig:
 
         self._cors_impl = _CorsConfigImpl(app, router_adapter)
 
-    def add(self, routing_entity, config: _ConfigType = None, webview: bool = False):
+    def add(
+        self,
+        routing_entity: Any,
+        config: Optional[_ConfigType] = None,
+        webview: bool = False,
+    ) -> Any:
         """Enable CORS for specific route or resource.
 
         If route is passed CORS is enabled for route's resource.

--- a/aiohttp_cors/mixin.py
+++ b/aiohttp_cors/mixin.py
@@ -1,10 +1,15 @@
 import collections
+from typing import Any, Callable, Mapping, TypeVar, Union
 
 from .preflight_handler import _PreflightHandler
+from .resource_options import ResourceOptions
+
+_ConfigArg = Mapping[str, Union[ResourceOptions, Mapping[str, Any]]]
+_F = TypeVar("_F", bound=Callable[..., Any])
 
 
-def custom_cors(config):
-    def wrapper(function):
+def custom_cors(config: _ConfigArg) -> Callable[[_F], _F]:
+    def wrapper(function: _F) -> _F:
         name = f"{function.__name__}_cors_config"
         setattr(function, name, config)
         return function

--- a/aiohttp_cors/resource_options.py
+++ b/aiohttp_cors/resource_options.py
@@ -17,11 +17,12 @@
 import collections
 import collections.abc
 import numbers
+from typing import Any, FrozenSet, Optional, Sequence, Union
 
 __all__ = ("ResourceOptions",)
 
 
-def _is_proper_sequence(seq):
+def _is_proper_sequence(seq: Any) -> bool:
     """Returns is seq is sequence and not string."""
     return isinstance(seq, collections.abc.Sequence) and not isinstance(seq, str)
 
@@ -45,12 +46,12 @@ class ResourceOptions(
     def __init__(
         self,
         *,
-        allow_credentials=False,
-        expose_headers=(),
-        allow_headers=(),
-        max_age=None,
-        allow_methods=None
-    ):
+        allow_credentials: bool = False,
+        expose_headers: Union[str, Sequence[str]] = (),
+        allow_headers: Union[str, Sequence[str]] = (),
+        max_age: Optional[int] = None,
+        allow_methods: Optional[Union[str, Sequence[str]]] = None
+    ) -> None:
         """Construct resource CORS options.
 
         Options will be normalized.
@@ -93,12 +94,12 @@ class ResourceOptions(
     def __new__(
         cls,
         *,
-        allow_credentials=False,
-        expose_headers=(),
-        allow_headers=(),
-        max_age=None,
-        allow_methods=None
-    ):
+        allow_credentials: bool = False,
+        expose_headers: Union[str, Sequence[str]] = (),
+        allow_headers: Union[str, Sequence[str]] = (),
+        max_age: Optional[int] = None,
+        allow_methods: Optional[Union[str, Sequence[str]]] = None
+    ) -> "ResourceOptions":
         """Normalize source parameters and store them in namedtuple."""
 
         if not isinstance(allow_credentials, bool):
@@ -109,6 +110,7 @@ class ResourceOptions(
         _allow_credentials = allow_credentials
 
         # `expose_headers` is either "*", or sequence of strings.
+        _expose_headers: Union[str, FrozenSet[str]]
         if expose_headers == "*":
             _expose_headers = expose_headers
         elif not _is_proper_sequence(expose_headers):
@@ -128,6 +130,7 @@ class ResourceOptions(
             _expose_headers = frozenset()
 
         # `allow_headers` is either "*", or set of headers in upper case.
+        _allow_headers: Union[str, FrozenSet[str]]
         if allow_headers == "*":
             _allow_headers = allow_headers
         elif not _is_proper_sequence(allow_headers):
@@ -149,6 +152,7 @@ class ResourceOptions(
                 )
             _max_age = max_age
 
+        _allow_methods: Optional[Union[str, FrozenSet[str]]]
         if allow_methods is None or allow_methods == "*":
             _allow_methods = allow_methods
         elif not _is_proper_sequence(allow_methods):
@@ -169,7 +173,7 @@ class ResourceOptions(
             allow_methods=_allow_methods,
         )
 
-    def is_method_allowed(self, method):
+    def is_method_allowed(self, method: str) -> bool:
         if self.allow_methods is None:
             return False
 


### PR DESCRIPTION
## Summary
- Add type hints to `ResourceOptions.__init__`/`__new__`, `custom_cors`, `CorsConfig.add`/`_CorsConfigImpl.add`, and `aiohttp_cors.setup`. Several of these had `= None` defaults on non-`Optional` parameter types, which mypy's strict mode (PEP 484 implicit-optional) rejects.
- Fix a README example that referenced `ResourceOption` (missing the trailing `s`).
- Replace the deprecated `@asyncio.coroutine` decorator with `async def` in the README usage examples.

Fixes #571

## Test plan
- [x] `mypy --strict` on the touched modules no longer reports the implicit-optional / missing-annotation errors described in the issue
- [x] `flake8`, `black --check`, `isort --check` all pass
- [x] `pytest` unit tests pass at parity with `master` (pre-existing failures in this environment are unrelated Python 3.14 / asyncio-mode issues already tracked by other open PRs)