### PR TITLE
Fix TypeError crash in _is_web_view for proxy-wrapped handlers

### DIFF
--- a/aiohttp_cors/urldispatcher_router_adapter.py
+++ b/aiohttp_cors/urldispatcher_router_adapter.py
@@ -88,17 +88,28 @@ def _is_web_view(entity, strict=True):
     webview = False
     if isinstance(entity, web.AbstractRoute):
         handler = entity.handler
-        if isinstance(handler, type) and issubclass(handler, web.View):
-            webview = True
-            if not issubclass(handler, CorsViewMixin):
-                if strict:
-                    raise ValueError(
-                        "web view should be derived from "
-                        "aiohttp_cors.CorsViewMixin for working "
-                        "with the library"
-                    )
-                else:
-                    return False
+        if isinstance(handler, type):
+            try:
+                is_web_view_subclass = issubclass(handler, web.View)
+            except TypeError:
+                # Some libraries (e.g. certain APM/tracing instrumentation)
+                # wrap handlers in proxy objects that satisfy
+                # `isinstance(handler, type)` (via a custom __class__
+                # property) without being real classes, which makes
+                # issubclass() raise "issubclass() arg 1 must be a class".
+                # Such handlers cannot be aiohttp.web.View subclasses.
+                is_web_view_subclass = False
+            if is_web_view_subclass:
+                webview = True
+                if not issubclass(handler, CorsViewMixin):
+                    if strict:
+                        raise ValueError(
+                            "web view should be derived from "
+                            "aiohttp_cors.CorsViewMixin for working "
+                            "with the library"
+                        )
+                    else:
+                        return False
     return webview
 
 

--- a/tests/unit/test_urldispatcher_router_adapter.py
+++ b/tests/unit/test_urldispatcher_router_adapter.py
@@ -22,6 +22,7 @@ from aiohttp import web
 from aiohttp_cors import ResourceOptions
 from aiohttp_cors.urldispatcher_router_adapter import (
     ResourcesUrlDispatcherRouterAdapter,
+    _is_web_view,
 )
 
 
@@ -113,3 +114,48 @@ def test_get_non_preflight_request_config(adapter, get_route):
             "http://example.org": ResourceOptions(),
             "http://test.example.org": ResourceOptions(),
         }
+
+
+def test_is_web_view_with_proxy_wrapped_handler():
+    """Regression test for #217.
+
+    Some instrumentation libraries (e.g. APM/tracing agents) wrap request
+    handlers in proxy objects that satisfy ``isinstance(handler, type)``
+    (typically via a custom ``__class__`` property) without being real
+    classes. ``_is_web_view()`` previously called
+    ``issubclass(handler, web.View)`` unconditionally once that isinstance
+    check passed, which crashes for such proxies with:
+
+        TypeError: issubclass() arg 1 must be a class
+
+    (aiohttp's own route construction performs an identical isinstance/
+    issubclass check and would raise the same error before a route with
+    such a handler could even be registered, so this exercises
+    ``_is_web_view`` directly against a mocked AbstractRoute rather than
+    through ``app.router.add_route``.)
+
+    A handler like this should simply be treated as "not a web view"
+    instead of crashing.
+    """
+
+    class _ProxyHandler:
+        """Mimics a proxy wrapper (e.g. wrapt.ObjectProxy-based APM
+        instrumentation) whose __class__ property fools isinstance() into
+        reporting it as a type, while issubclass() rejects it."""
+
+        @property
+        def __class__(self):
+            return type
+
+        def __call__(self, request):
+            return _handler(request)
+
+    proxy_handler = _ProxyHandler()
+    assert isinstance(proxy_handler, type)  # sanity check on the proxy trick
+
+    route_obj = mock.Mock(spec=web.AbstractRoute)
+    route_obj.handler = proxy_handler
+
+    # Must not raise TypeError; a proxy that fails issubclass() is simply
+    # not a web view.
+    assert _is_web_view(route_obj) is False


### PR DESCRIPTION
## Problem

`_is_web_view()` crashes with `TypeError: issubclass() arg 1 must be a class` for handlers wrapped by certain instrumentation/proxy libraries, as reported in #217 (there, `newrelic.agent.initialize()`):

```python
if isinstance(handler, type) and issubclass(handler, web.View):
```

Some proxy wrapper objects (e.g. `wrapt.ObjectProxy`-based APM/tracing instrumentation) implement a custom `__class__` property so that `isinstance(handler, type)` returns `True`, without the object actually being usable with `issubclass()`. Once `isinstance` passes, `issubclass(handler, web.View)` is called unconditionally and raises, crashing `CorsConfig.add()` / `add_preflight_handler()` for any route using such a handler.

(aiohttp's own `ResourceRoute.__init__` has the identical isinstance/issubclass pattern and is equally susceptible when *registering* such a route — but `aiohttp_cors` shouldn't compound that fragility when merely inspecting an existing route.)

## Fix

Wrap the `issubclass()` call in a `try`/`except TypeError`, treating a handler that fails the check as "not a web view" (since a value issubclass() rejects can't be an `aiohttp.web.View` subclass anyway):

```python
if isinstance(handler, type):
    try:
        is_web_view_subclass = issubclass(handler, web.View)
    except TypeError:
        is_web_view_subclass = False
    if is_web_view_subclass:
        ...
```

## Testing

Added `test_is_web_view_with_proxy_wrapped_handler` to `tests/unit/test_urldispatcher_router_adapter.py`, which constructs a minimal proxy class reproducing the exact isinstance/issubclass mismatch (a `__class__` property returning `type`) and asserts `_is_web_view()` returns `False` rather than raising. The test drives `_is_web_view()` directly against a `mock.Mock(spec=web.AbstractRoute)` rather than through `app.router.add_route()`, since aiohttp's own route construction has the identical check and would raise the same `TypeError` before such a route could even be registered — confirmed by trying that approach first and hitting the crash one layer up, in `aiohttp/web_urldispatcher.py`.

Verified:
- Full `tests/unit` suite before the change: 2 failed (pre-existing, unrelated — missing async pytest plugin registration in this environment: `test_raises_forbidden_when_config_not_found`, `test_raises_when_handler_not_extend`), 19 passed.
- After the fix + new test: same 2 pre-existing failures, 20 passed (the 19 plus the new test).
- Reverting just the fix (keeping the test) reproduces the exact reported `TypeError: issubclass() arg 1 must be a class`; reapplying passes again.

Fixes #217.
